### PR TITLE
powerd: Add sleep.internal permissions

### DIFF
--- a/files/sysbus/com.palm.power.perm.json
+++ b/files/sysbus/com.palm.power.perm.json
@@ -3,6 +3,7 @@
         "devices",
         "system",
         "activities.manage",
-        "signals.all"
+        "signals.all",
+        "sleep.internal"
     ]
 }


### PR DESCRIPTION
Solves:

2020-06-11T16:19:55.396832Z [5.721049228] user.warning sleepd [] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"com.palm.power","CATEGORY":"/com/palm/power","METHOD":"identify"} Service security groups don't allow method call.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>