### PR TITLE
ACG: allow "sleep.internal" group, to call shutdown/machineOff on sleepd

### DIFF
--- a/files/sysbus/com.palm.power.perm.json
+++ b/files/sysbus/com.palm.power.perm.json
@@ -3,6 +3,7 @@
         "devices",
         "system",
         "activities.manage",
-        "signals.all"
+        "signals.all",
+        "sleep.internal"
     ]
 }


### PR DESCRIPTION
Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>